### PR TITLE
Fix length of paginated results

### DIFF
--- a/src/models/video.js
+++ b/src/models/video.js
@@ -234,7 +234,7 @@ VideoSchema.statics.search = function (query, cb) {
     parseResult.hasNext = result.length > limit
     parseResult.query = originalQuery
     // compensate hasNext increment
-    parseResult.total = result.length - 1
+    parseResult.total = result.length - 2
     return cb(null, parseResult)
   })
 


### PR DESCRIPTION
**Issue**
[paratii-js#218](https://github.com/Paratii-Video/paratii-js/issues/218)

**Work Done**
Fix length of paginated results so that they return exactly the `limit` specified in the query, and not one more.